### PR TITLE
Add procps package for using pgrep

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -1,2 +1,3 @@
 hostname
-mariadb-server
+mariadb-server 
+procps


### PR DESCRIPTION
This PR adds `procps` package for the use of `pgrep`: https://github.com/metal3-io/mariadb-image/blob/48d8bffa484c4d2091f7416aa53f488f96610172/runmariadb#L25