### PR TITLE
add SECURITY_CONTACTS file

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,11 @@
+# Reporting a security vulnerability
+
+Please do:
+  - not disclose any security issue publicly e.g. Pull Requests, Comments.
+  - not disclose any security issue directly to any owner of the repository or
+    to any other contributor.
+
+In this repository security reports are handled according to the
+Metal3-io project's security policy. For more information about the security
+policy consult the User-Guide [here](https://book.metal3.io/security_policy.html).
+


### PR DESCRIPTION
For any maintained repo under metal3-io, we need to have certain set
of files present. After a discussion, it was agreed that this repo
is not ready for archival.
