### PR TITLE
make mariadb runnable as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/centos/centos:stream8
+ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
 FROM $BASE_IMAGE
 
@@ -6,8 +6,9 @@ ENV PKGS_LIST=main-packages-list.txt
 ARG EXTRA_PKGS_LIST
 
 COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} /tmp/
-COPY prepare-image.sh runmariadb /bin/
+COPY prepare-image.sh configure-nonroot.sh runmariadb /bin/
 
 RUN /bin/prepare-image.sh && rm -f /bin/prepare-image.sh
+RUN /bin/configure-nonroot.sh && rm -f /bin/configure-nonroot.sh
 
 ENTRYPOINT /bin/runmariadb

--- a/configure-nonroot.sh
+++ b/configure-nonroot.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+#
+# configure mysql image to run with mysql user
+# changes are backwards compatible for running as root
+
+set -eux
+
+# mysql user uid/gid
+# NONROOT_UID=27
+NONROOT_GID=27
+
+mkdir -p /certs
+chgrp -R "${NONROOT_GID}" /certs
+chmod 2775 /certs
+
+chgrp -R "${NONROOT_GID}" /etc/my.cnf.d
+chmod 2775 /etc/my.cnf.d
+chmod -R g+w /etc/my.cnf.d/*
+
+mkdir -p /var/lib/mysql
+chgrp -R "${NONROOT_GID}" /var/lib/mysql
+chmod -R g+w /var/lib/mysql

--- a/runmariadb
+++ b/runmariadb
@@ -1,4 +1,7 @@
 #!/usr/bin/bash
+
+set -eux
+
 PATH=$PATH:/usr/sbin/
 DATADIR="/var/lib/mysql"
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
@@ -6,8 +9,9 @@ MARIADB_CONF_FILE="/etc/my.cnf.d/mariadb-server.cnf"
 MARIADB_CERT_FILE=/certs/mariadb/tls.crt
 MARIADB_KEY_FILE=/certs/mariadb/tls.key
 RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
+USER="$(whoami)"
 
-mkdir -p $(dirname ${MARIADB_CERT_FILE})
+mkdir -p "$(dirname "${MARIADB_CERT_FILE}")"
 if [ -f "$MARIADB_CERT_FILE" ] && [ ! -f "$MARIADB_KEY_FILE" ] ; then
     echo "Missing TLS private key file ${MARIADB_KEY_FILE}"
     exit 1
@@ -21,8 +25,9 @@ ln -sf /proc/self/fd/1 /var/log/mariadb/mariadb.log
 
 # Restart mysqld when the certificate is updated
 if [[ -f "$MARIADB_CERT_FILE" && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
+    # shellcheck disable=SC2034,SC2162
     inotifywait -m -e delete_self "${MARIADB_CERT_FILE}" | while read file event; do
-       kill $(pgrep -f mysqld)
+        kill $(pgrep -f mysqld)
     done &
 fi
 
@@ -31,19 +36,16 @@ if [ ! -d "${DATADIR}/mysql" ]; then
     crudini --set "$MARIADB_CONF_FILE" mysqld max_heap_table_size 1M
     crudini --set "$MARIADB_CONF_FILE" mysqld innodb_buffer_pool_size 5M
     crudini --set "$MARIADB_CONF_FILE" mysqld innodb_log_buffer_size 512K
-    crudini --set "$MARIADB_CONF_FILE" mysqld user root
+    crudini --set "$MARIADB_CONF_FILE" mysqld user "${USER}"
 
     # Config MariaDB to enable TLS
-    if [ -f "$MARIADB_CERT_FILE" ]
-    then
-      crudini --set "$MARIADB_CONF_FILE" mariadb-10.3 ssl on
-      crudini --set "$MARIADB_CONF_FILE" mariadb-10.3 ssl_cert "${MARIADB_CERT_FILE}"
-      crudini --set "$MARIADB_CONF_FILE" mariadb-10.3 ssl_key "${MARIADB_KEY_FILE}"
+    if [ -f "$MARIADB_CERT_FILE" ]; then
+        crudini --set "$MARIADB_CONF_FILE" mariadb-10.3 ssl on
+        crudini --set "$MARIADB_CONF_FILE" mariadb-10.3 ssl_cert "${MARIADB_CERT_FILE}"
+        crudini --set "$MARIADB_CONF_FILE" mariadb-10.3 ssl_key "${MARIADB_KEY_FILE}"
     fi
 
-    mysql_install_db --datadir="$DATADIR"
-
-    chown -R mysql "$DATADIR"
+    mysql_install_db --datadir="$DATADIR" --skip-test-db --user="${USER}" --group="${USER}"
 
     cat > /tmp/configure-mysql.sql <<-EOSQL
 DELETE FROM mysql.user ;


### PR DESCRIPTION
In effort to run BMO as non-root, we also need to have mariadb run as non-root. We can reuse mysql user (uid/gid 27) as we only read from shared volumes and do not need to use same fsGroup as others.

This change should be backwards compatible, and should work fine without BMO manifest change as well. All configuration allows using root user as before.

Base image is also updated from Stream 8 to Stream 9.