### PR TITLE
add basic linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-Metal3 MariaDB Container
-========================
+# Metal3 MariaDB Container
 
-This repo contains the files needed to build the MariaDB image used by Metal3.
+This repo contains the files needed to build the MariaDB image optionally used
+by Metal3.
 
-Description
------------
+## Description
 
-The following environment variables can be passed in to customize run-time functionality:
+The following environment variables can be passed in to customize run-time
+functionality:
+
 - `MARIADB_PASSWORD` - The database password. Must match one on Ironic.
-- `MARIADB_CERT_FILE` and `MARIADB_KEY_FILE` - Paths to the TLS certificates.  Default to `/certs/mariadb/tls.crt` and `/certs/mariadb/tls.key`. TLS is enabled if these exist.
+- `MARIADB_CERT_FILE` and `MARIADB_KEY_FILE` - Paths to the TLS certificates.
+   Default to `/certs/mariadb/tls.crt` and `/certs/mariadb/tls.key`.
+   TLS is enabled if these exist.

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    TOP_DIR="${1:-.}"
+    find "${TOP_DIR}" -type d \( -path ./vendor -o -path ./.github \) -prune -o -name '*.md' -exec mdl --style all --warnings {} \+
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
+        /workdir/hack/markdownlint.sh "$@"
+fi

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    TOP_DIR="${1:-.}"
+    find "${TOP_DIR}" -path ./vendor -prune -o -name '*.sh' -exec shellcheck -s bash {} \+
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7 \
+        /workdir/hack/shellcheck.sh "$@"
+fi

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -9,11 +9,11 @@ echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
 dnf install -y epel-release 'dnf-command(config-manager)' python3-pip
 dnf config-manager --set-disabled epel
 
-xargs -rtd'\n' dnf install -y < /tmp/${PKGS_LIST}
+xargs -rtd'\n' dnf install -y < /tmp/"${PKGS_LIST}"
 
-if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
-    if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
-        xargs -rtd'\n' dnf install -y < /tmp/${EXTRA_PKGS_LIST}
+if [[ -n "${EXTRA_PKGS_LIST:-}" ]]; then
+    if [[ -s /tmp/"${EXTRA_PKGS_LIST}" ]]; then
+        xargs -rtd'\n' dnf install -y < /tmp/"${EXTRA_PKGS_LIST}"
     fi
 fi
 


### PR DESCRIPTION
Add markdownlint and shellcheck to hack/ to do basic linting. Fix existing errors in the README.md and prepare-image.sh

CI for using these will be added by another PR to project-infra later.