### PR TITLE
Revert "pin stream9 base image to a sha digest"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/centos/centos:stream9@sha256:06cfbf69d99f47f45f327d18fec086509ca0c74afdb178fb8c5bc45184454cc0
+ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
This reverts commit 8719b4819b200f27a654f682821f74cfa95c1c5b.

Quay.io cleans up SHA references of stream9 images, so they're not reliable.