### PR TITLE
Add github action to trigger mariadb container image build

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -1,0 +1,27 @@
+name: build-images-action
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release-*'
+permissions: {}
+jobs:
+  build:
+    name: Build container images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: build mariabd image
+        uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
+        with:
+          jenkins_url: "https://jenkins.nordix.org/"
+          jenkins_user: "metal3.bot@gmail.com"
+          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
+          job_name: "metal3_mariadb_container_image_building"
+          job_params: |
+            {
+              "BUILD_CONTAINER_IMAGE_NAME": "mariadb",
+              "BUILD_CONTAINER_IMAGE_BRANCH": "${{ github.ref }}"
+            }
+          job_timeout: "1000"


### PR DESCRIPTION
This PR adds an action to trigger the mariadb container build whenever a PR is merged in this repo.