### PR TITLE
Prevent github build action runs on forks

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Build container images
     runs-on: ubuntu-latest
+    if: github.repository == 'metal3-io/mariadb-image'
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
This PR prevents the build action to run on forks of this repo