### PR TITLE
bump markdownlint to 0.13.0

### DIFF
--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -14,6 +14,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
+        docker.io/pipelinecomponents/markdownlint:0.13.0@sha256:9c0cdfb64fd3f1d3bdc5181629b39c2e43b6a52fc9fdc146611e1860845bbae0 \
         /workdir/hack/markdownlint.sh "$@"
 fi


### PR DESCRIPTION
Bump markdownlint to 0.13.0. No extra fixes needed in MariaDB, and this should be cherry-picked to release branches to keep project-infra config simpler.

TODO: bump the image in project-infra when all bump PRs are merged.