### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,21 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - bfournie
- - derekhiggins
- - dtantsur
- - elfosardo
- - kashifest
+- mariadb-image-maintainers
 
 reviewers:
- - iurygregory
- - lentzi90
- - stbenjam
- - zaneb
+- mariadb-image-maintainers
+- mariadb-image-reviewers
 
 emeritus_approvers:
- - hardys
+- hardys
 
 emeritus_reviewers:
- - maelk
- - namnx228
+- maelk
+- namnx228

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  mariadb-image-maintainers:
+  - bfournie
+  - derekhiggins
+  - dtantsur
+  - elfosardo
+  - kashifest
+
+  mariadb-image-reviewers:
+  - iurygregory
+  - lentzi90
+  - stbenjam
+  - zaneb


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.