### PR TITLE
Allow mounting secrets instead of providing password via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The following environment variables can be passed in to customize run-time
 functionality:
 
 - `MARIADB_PASSWORD` - The database password. Must match one on Ironic.
+   Alternatively, mount a secret with `password` (optionally with a `username`)
+   at `/auth/mariadb` mount point.
 - `MARIADB_CERT_FILE` and `MARIADB_KEY_FILE` - Paths to the TLS certificates.
    Default to `/certs/mariadb/tls.crt` and `/certs/mariadb/tls.key`.
    TLS is enabled if these exist.

--- a/runmariadb
+++ b/runmariadb
@@ -2,12 +2,23 @@
 
 set -eu
 
+AUTHROOT=/auth/mariadb
+
+if [[ -z "${MARIADB_PASSWORD:-}" ]] && [[ -f "${AUTHROOT}/password" ]]; then
+    MARIADB_PASSWORD="$(<"${AUTHROOT}"/password)"
+fi
+
 if [[ -z "${MARIADB_PASSWORD:-}" ]]; then
-    echo "FATAL: Missing database password, set the MARIADB_PASSWORD variable"
+    echo "FATAL: Missing database password"
+    echo "HINT: mount the secret at ${AUTHROOT} or set the MARIADB_PASSWORD variable"
     exit 1
 fi
 
 set -x
+
+if [[ -z "${MARIADB_USER:-}" ]] && [[ -f "${AUTHROOT}/username" ]]; then
+    MARIADB_USER="$(<"${AUTHROOT}"/username)"
+fi
 
 PATH=$PATH:/usr/sbin/
 DATADIR="/var/lib/mysql"


### PR DESCRIPTION
It's potentially more secure this way and is also more consistent with
how ironic-image does the same thing.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
