### PR TITLE
:seedling: move functional test to larger github runner

### DIFF
--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       LOGDIR: /tmp/logs
     steps:


### PR DESCRIPTION
Functional test needs more disk space than is available in normal runner. Move it to larger runners.