### PR TITLE
lint: allow long lines in tables and code fences

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,6 +4,9 @@ config:
   ul-indent:
     # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
     indent: 3
+  line-length:
+    tables: false
+    code_blocks: false
 
 # Don't autofix anything, we're linting here
 fix: false


### PR DESCRIPTION
Allow lines longer than 80 chars, if they're in tables or code fences. In those, long lines cannot often be avoided, and ignoring them one by one is painful and not pretty.

The same change is applied to all repos with markdownlint, but only on main. Documentation is 99% of the time maintained only in main, so it doesn't matter in release branches.